### PR TITLE
DIAN-166

### DIFF
--- a/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/HmDataModel.java
+++ b/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/HmDataModel.java
@@ -51,6 +51,8 @@ import static org.sagebionetworks.dian.datamigration.MigrationUtil.NO_DEVICE_ID;
  */
 public class HmDataModel {
 
+    public static final long NO_DEVICE_ID_CREATED_ON = 0;
+
     /**
      * This class is used to compile the need to know data
      * about a Happy Medium user, all in one data class
@@ -72,6 +74,8 @@ public class HmDataModel {
         // This is only available to the user and HM's servers.
         // We use it as a one-time use activation code to transfer the user's data.
         public String deviceId;
+        // When the deviceId was created on HM's server.
+        public long deviceIdCreatedAt;
         // The site location managing the user.
         // For HASD, this is always Marisol at WashU.
         // For DIAN_OBS, this will be whichever university or organization running the sub-study
@@ -128,8 +132,13 @@ public class HmDataModel {
                 this.studyId = ERROR_STUDY_ID;
                 this.externalId = this.arcId;
                 this.password = PasswordGenerator.INSTANCE.nextPassword();
-                this.deviceId = participantDeviceId == null ?
-                        NO_DEVICE_ID : participantDeviceId.device_id;
+                if (participantDeviceId == null ) {
+                    this.deviceId = NO_DEVICE_ID;
+                    this.deviceIdCreatedAt = NO_DEVICE_ID_CREATED_ON;
+                } else {
+                    this.deviceId = participantDeviceId.device_id;
+                    this.deviceIdCreatedAt = Long.parseLong(participantDeviceId.created_at);
+                }
                 this.notes = errorNote;
                 return;
             }
@@ -145,6 +154,7 @@ public class HmDataModel {
             if (participantDeviceId == null) {
                 System.out.println("Unused user for site " + this.arcId);
                 this.deviceId = NO_DEVICE_ID;
+                this.deviceIdCreatedAt = NO_DEVICE_ID_CREATED_ON;
                 this.externalId = this.arcId;
                 this.password = PasswordGenerator.INSTANCE.nextPassword();
                 return;
@@ -157,6 +167,7 @@ public class HmDataModel {
             // device-id to download their data and create a new account on Bridge.
             System.out.println("Migrating user account as device-id " + this.arcId);
             this.deviceId = participantDeviceId.device_id;
+            this.deviceIdCreatedAt = Long.parseLong(participantDeviceId.created_at);
             this.externalId = this.deviceId;
             this.password = this.deviceId;
         }
@@ -399,12 +410,16 @@ public class HmDataModel {
             public String participant;
             // The participant's most recent device id
             public String device_id;
+            // A string representation of long value timestamp seconds since 1970
+            public String created_at;
 
             public ParticipantDeviceId() {}
-            public ParticipantDeviceId(String tableId, String participantTableId, String deviceId) {
+            public ParticipantDeviceId(String tableId, String participantTableId,
+                                       String deviceId, String createdAt) {
                 this.id = tableId;
                 this.participant = participantTableId;
                 this.device_id = deviceId;
+                this.created_at = createdAt;
             }
         }
 

--- a/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/PasswordGenerator.java
+++ b/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/PasswordGenerator.java
@@ -58,7 +58,8 @@ public class PasswordGenerator {
     public static final String NUMERIC = "123456789";
     // Bridge password must contain at least one symbol ( !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~ );
     // This subset of symbols was chosen because they would be easier to communicate over the phone
-    public static final String SYMBOLIC = "!#$%&'*+,-.:;=?@_";
+    // As well as removing some that the older participants wouldn't understand
+    public static final String SYMBOLIC = "&.!?";
 
     private static final char[] UPPERCASE_ARRAY = UPPERCASE.toCharArray();
     private static final char[] LOWERCASE_ARRAY = LOWERCASE.toCharArray();

--- a/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/BridgeJavaSdkUtilTests.java
+++ b/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/BridgeJavaSdkUtilTests.java
@@ -408,7 +408,7 @@ public class BridgeJavaSdkUtilTests extends Mockito {
         assertNotNull(signUp.getAttributes());
     }
 
-    private HmDataModel.HmUser createExistingUser() {
+    public static HmDataModel.HmUser createExistingUser() {
         HmDataModel.HmUser user = new HmDataModel.HmUser();
         String arcId = "000000";
         String deviceId = "d1a5cbaf-288c-48dd-9d4a-98c90213ac01";
@@ -420,7 +420,7 @@ public class BridgeJavaSdkUtilTests extends Mockito {
         return user;
     }
 
-    private HmDataModel.HmUser createNewUser() {
+    public static HmDataModel.HmUser createNewUser() {
         HmDataModel.HmUser user = new HmDataModel.HmUser();
         String arcId = "000000";
         String deviceId = "d1a5cbaf-288c-48dd-9d4a-98c90213ac01";
@@ -433,7 +433,7 @@ public class BridgeJavaSdkUtilTests extends Mockito {
         return user;
     }
 
-    private HmDataModel.HmUserData createNewUserData(String arcId) {
+    public static HmDataModel.HmUserData createNewUserData(String arcId) {
         HmDataModel.HmUserData data = new HmDataModel.HmUserData();
         data.completedTests = null;
         data.testSessionSchedule = null;

--- a/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/HmDataModelTests.java
+++ b/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/HmDataModelTests.java
@@ -217,9 +217,11 @@ public class HmDataModelTests {
         HmDataModel.TableRow.ParticipantDeviceId[] userDeviceIdList =
                 new HmDataModel.TableRow.ParticipantDeviceId[] {
                         new HmDataModel.TableRow.ParticipantDeviceId(
-                                "1", "1", "d1a5cbaf-288c-48dd-9d4a-98c90213ac01"),
+                                "1", "1",
+                                "d1a5cbaf-288c-48dd-9d4a-98c90213ac01", "1576165222"),
                         new HmDataModel.TableRow.ParticipantDeviceId(
-                                "2", "2", "abc5cbaf-288c-48dd-9d4a-98c90213ac01")
+                                "2", "2",
+                                "abc5cbaf-288c-48dd-9d4a-98c90213ac01", "1576165222")
                 };
 
         HmDataModel.TableRow.ParticipantDeviceId deviceId =
@@ -378,7 +380,8 @@ public class HmDataModelTests {
         params.notes = new HmDataModel.TableRow.ParticipantNotes("1", "1", "Note");
         params.phone = new HmDataModel.TableRow.ParticipantPhone("1", "1", "+11111111111");
         params.participantDeviceId = new HmDataModel.TableRow.
-                ParticipantDeviceId("1", "1", "d1a5cbaf-288c-48dd-9d4a-98c90213ac01");
+                ParticipantDeviceId("1", "1",
+                "d1a5cbaf-288c-48dd-9d4a-98c90213ac01", "1576165222");
         return params;
     }
 


### PR DESCRIPTION
See jira issue for a full description of the problem https://sagebionetworks.jira.com/browse/DIAN-166 

To solve it, I added conflict resolution for duplicate participant table rows to favor a valid device ID, and if there are two valid device IDs, take the most recently created one.  

Unit tests were added for the conflict resolution function as well as to `test_createHmUserRaterData` to verify that the list of created users does not contain duplicates.