### PR TITLE
PasswordRequirements

### DIFF
--- a/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/HmDataModel.java
+++ b/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/HmDataModel.java
@@ -52,6 +52,8 @@ import static org.sagebionetworks.dian.datamigration.MigrationUtil.NO_DEVICE_ID;
 public class HmDataModel {
 
     public static final long NO_DEVICE_ID_CREATED_ON = 0;
+    // Device IDs cannot meet the bridge password requirements alone, so append this to the end
+    public static final String ARC_PASSWORD_REQUIREMENTS = "Arc#";
 
     /**
      * This class is used to compile the need to know data
@@ -169,7 +171,7 @@ public class HmDataModel {
             this.deviceId = participantDeviceId.device_id;
             this.deviceIdCreatedAt = Long.parseLong(participantDeviceId.created_at);
             this.externalId = this.deviceId;
-            this.password = this.deviceId;
+            this.password = this.deviceId + ARC_PASSWORD_REQUIREMENTS;
         }
     }
 

--- a/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/HmDataModelTests.java
+++ b/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/HmDataModelTests.java
@@ -57,7 +57,7 @@ public class HmDataModelTests {
         assertEquals("SiteA", user.studyId);
         assertEquals("+11111111111", user.phone);
         // Existing users will migrate with their password as also their Device ID
-        assertEquals("d1a5cbaf-288c-48dd-9d4a-98c90213ac01", user.password);
+        assertEquals("d1a5cbaf-288c-48dd-9d4a-98c90213ac01Arc#", user.password);
         assertNull(user.name);
         assertEquals("Note", user.notes);
         assertEquals(user.rater.email, params.rater.email);

--- a/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/MigrationTests.java
+++ b/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/MigrationTests.java
@@ -189,7 +189,7 @@ public class MigrationTests {
 
         user = users.get(1);
         assertEquals("d1a5cbaf-288c-48dd-9d4a-98c90213ac01", user.externalId);
-        assertEquals("d1a5cbaf-288c-48dd-9d4a-98c90213ac01", user.password);
+        assertEquals("d1a5cbaf-288c-48dd-9d4a-98c90213ac01Arc#", user.password);
         assertEquals("000002", user.arcId);
         assertEquals("d1a5cbaf-288c-48dd-9d4a-98c90213ac01", user.deviceId);
         assertEquals("EXR_Test2", user.name);
@@ -203,7 +203,7 @@ public class MigrationTests {
         user = users.get(2);
         assertEquals("200007", user.arcId);
         assertEquals("E402924D-34CE-443B-9E53-C0466440D622", user.externalId);
-        assertEquals("E402924D-34CE-443B-9E53-C0466440D622", user.password);
+        assertEquals("E402924D-34CE-443B-9E53-C0466440D622Arc#", user.password);
         assertEquals("E402924D-34CE-443B-9E53-C0466440D622", user.deviceId);
         assertEquals("HASD_Test2", user.name);
         assertEquals("2-SDP", user.studyId);
@@ -215,7 +215,7 @@ public class MigrationTests {
         user = users.get(3);
         assertEquals("555555", user.arcId);
         assertEquals("7799c212-49aa-417a-8f8d-a7d50390d558", user.externalId);
-        assertEquals("7799c212-49aa-417a-8f8d-a7d50390d558", user.password);
+        assertEquals("7799c212-49aa-417a-8f8d-a7d50390d558Arc#", user.password);
         assertEquals("7799c212-49aa-417a-8f8d-a7d50390d558", user.deviceId);
         assertEquals("HASD_Test1", user.name);
         assertEquals("2-SDP", user.studyId);
@@ -227,7 +227,7 @@ public class MigrationTests {
         user = users.get(4);
         assertEquals("626017", user.arcId);
         assertEquals("193A86E0-892F-4230-9688-2D9E4B1556F9", user.externalId);
-        assertEquals("193A86E0-892F-4230-9688-2D9E4B1556F9", user.password);
+        assertEquals("193A86E0-892F-4230-9688-2D9E4B1556F9Arc#", user.password);
         assertEquals("193A86E0-892F-4230-9688-2D9E4B1556F9", user.deviceId);
         assertEquals("OBS_Test1", user.name);
         assertEquals("3-Sage", user.studyId);

--- a/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/PathsHelperTests.java
+++ b/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/PathsHelperTests.java
@@ -163,9 +163,7 @@ public class PathsHelperTests {
         files.sort((o1, o2) -> o1.getFileName().toString()
                 .compareTo(o2.getFileName().toString()));
         assertEquals("a.json", files.get(0).getFileName().toString());
-        assertEquals("FolderC", files.get(0).getParent().getFileName().toString());
         assertEquals("a.json", files.get(1).getFileName().toString());
-        assertEquals("FolderA", files.get(1).getParent().getFileName().toString());
         assertEquals("b.json", files.get(2).getFileName().toString());
         assertEquals("c.json", files.get(3).getFileName().toString());
         assertEquals("d.json", files.get(4).getFileName().toString());

--- a/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/PathsHelperTests.java
+++ b/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/PathsHelperTests.java
@@ -166,7 +166,7 @@ public class PathsHelperTests {
                 return o1.getParent().getFileName().toString().compareTo(
                         o2.getParent().getFileName().toString());
             }
-            return o1.getFileName().compareTo(o2.getFileName());
+            return o1.getFileName().toString().compareTo(o2.getFileName().toString());
         });
         assertEquals("a.json", files.get(0).getFileName().toString());
         assertEquals("FolderA", files.get(0).getParent().getFileName().toString());

--- a/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/PathsHelperTests.java
+++ b/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/PathsHelperTests.java
@@ -41,6 +41,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -160,10 +161,17 @@ public class PathsHelperTests {
         assertNotNull(files);
         assertEquals(6, files.size());
         // Sort so that we can access by index
-        files.sort((o1, o2) -> o1.getFileName().toString()
-                .compareTo(o2.getFileName().toString()));
+        files.sort((o1, o2) -> {
+            if (o1.getFileName().toString().equals(o2.getFileName().toString())) {
+                return o1.getParent().getFileName().toString().compareTo(
+                        o2.getParent().getFileName().toString());
+            }
+            return o1.getFileName().compareTo(o2.getFileName());
+        });
         assertEquals("a.json", files.get(0).getFileName().toString());
+        assertEquals("FolderA", files.get(0).getParent().getFileName().toString());
         assertEquals("a.json", files.get(1).getFileName().toString());
+        assertEquals("FolderC", files.get(1).getParent().getFileName().toString());
         assertEquals("b.json", files.get(2).getFileName().toString());
         assertEquals("c.json", files.get(3).getFileName().toString());
         assertEquals("d.json", files.get(4).getFileName().toString());

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Before the migration can complete successfully, a sub-study must be created for 
 Depending on the state of the user, there are three migration scenarios that can occur.
 ### Migrating existing users
 A user is existing if they have an Arc ID, a site location, and a Device ID.
-These users will not have their account created yet with their Arc ID as their External ID.  Instead, the migration code will create an External ID that is their Device ID. The password for this account will also be their Device ID.
+These users will not have their account created yet with their Arc ID as their External ID.  Instead, the migration code will create an External ID that is their Device ID. The password for this account will also be their Device ID, plus the String "Arc#" that enables it to meet Bridge's password requirements.
 
 The migration code marks this user with the **test_user** data group, has their user attribute **IS_MIGRATED** set to **false**, and populates the account with that user's data.
 


### PR DESCRIPTION
The migration account passwords did not meet the default Bridge password requirements, as they never have both lowercase AND uppercase characters, only one or the other.  

To make sure they do meet them, I have appended text to the end of all migration account passwords.  

Unit tests have been run successfully.
I have also deleted all migration accounts on the Arc Validation Bridge server, and re-run the migration code, and all migration accounts were created successfully with the new password format.