### PR TITLE
attribute_bug

### DIFF
--- a/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/BridgeJavaSdkUtil.java
+++ b/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/BridgeJavaSdkUtil.java
@@ -248,7 +248,13 @@ public class BridgeJavaSdkUtil {
         if (user.phone != null) {
             attributeMap.put(ATTRIBUTE_PHONE_NUM, user.phone);
         }
-        attributeMap.put(ATTRIBUTE_IS_MIGRATED, ATTRIBUTE_VALUE_FALSE);
+
+        // If the new user is a 6-digit Arc ID, there is no need for IS_MIGRATED to have a value.
+        // IS_MIGRATED is meant for migration accounts that have long Device IDs as their external IDs.
+        if (user.externalId.length() != MigrationUtil.PARTICIPANT_ID_LENGTH) {
+            attributeMap.put(ATTRIBUTE_IS_MIGRATED, ATTRIBUTE_VALUE_FALSE);
+        }
+
         attributeMap.put(ATTRIBUTE_ARC_ID, user.arcId);
         attributeMap.put(ATTRIBUTE_RATER_EMAIL, raterEmail);
 

--- a/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/BridgeJavaSdkUtilTests.java
+++ b/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/BridgeJavaSdkUtilTests.java
@@ -314,15 +314,17 @@ public class BridgeJavaSdkUtilTests extends Mockito {
         HmDataModel.HmUser user = new HmDataModel.HmUser();
         String password = "5tm95s?ES?qTx5iGeLmb";
         user.arcId = "000000";
+        user.externalId = "000000";
         user.password = password;
         Map<String, String> attributes = BridgeJavaSdkUtil.newUserAttributes(user);
         assertNotNull(attributes);
         assertEquals("000000", attributes.get("ARC_ID"));
         assertEquals(password, attributes.get("VERIFICATION_CODE"));
+        assertEquals("No rater assigned yet", attributes.get("RATER_EMAIL"));
+        // New users that are Arc IDs do not need migrated, and should not be labeled as such
+        assertNull(attributes.get("IS_MIGRATED"));
         assertNull(attributes.get("PHONE_NUMBER"));
         assertNull(attributes.get("SITE_NOTES"));
-        assertEquals("false", attributes.get("IS_MIGRATED"));
-        assertEquals("No rater assigned yet", attributes.get("RATER_EMAIL"));
     }
 
     @Test
@@ -330,6 +332,8 @@ public class BridgeJavaSdkUtilTests extends Mockito {
         HmDataModel.HmUser user = new HmDataModel.HmUser();
         String password = "5tm95s?ES?qTx5iGeLmb";
         user.arcId = "000000";
+        user.externalId = "d1a5cbaf-288c-48dd-9d4a-98c90213ac01";
+        user.deviceId = "d1a5cbaf-288c-48dd-9d4a-98c90213ac01";
         user.password = password;
         user.phone = "+11111111111";
         user.notes = "Notes";


### PR DESCRIPTION
I found this minor bug while looking at the few accounts that were created by the migration code on ARC bridge project.

I removed the IS_MIGRATED attribute for new Arc IDs accounts. These accounts are not going to go through migration, and labeling them as not migrated yet, will make it more difficult for us to track the migration adherence percentage.