### PR TITLE
legacy_site

### DIFF
--- a/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/HmDataModel.java
+++ b/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/HmDataModel.java
@@ -145,7 +145,7 @@ public class HmDataModel {
                 return;
             }
 
-            site.name = MigrationUtil.bridgifySiteName(site.name);
+            site.name = MigrationUtil.bridgifyAndTranslateSiteName(site.name);
             // We can assign these for the remaining cases
             this.studyId = site.name;
             this.siteLocation = site;

--- a/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/MigrationUtil.java
+++ b/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/MigrationUtil.java
@@ -78,6 +78,13 @@ public class MigrationUtil {
     public static String ERROR_STUDY_ID = "Happy-Medium-Errors";
     public static String NO_DEVICE_ID = "No-Device-Id";
 
+    public static final String EXR_SITE_LOCATION = "EXR";
+    public static final String LEGACY_EXR_SITE_LOCATION = "Legacy";
+    // There are some site IDs that need translated to other site locations, define them here
+    public static Map<String, String> SITE_LOCATION_TRANSLATION  = new HashMap<String, String>() {{
+        put(LEGACY_EXR_SITE_LOCATION, EXR_SITE_LOCATION);
+    }};
+
     /**
      * Each file in the parameter list represents a directory
      * where the user's data JSON files were unzipped to.
@@ -370,14 +377,22 @@ public class MigrationUtil {
     /**
      * Bridge does not allow apostrophes, periods, or spaces in site names,
      * and HappyMedium had some, so we must remove them.
+     * There are some site IDs that need translated to other site's,
+     * like "Legacy" belongs in "EXR", so do that as well here.
      * @param siteName to convert to a bridge acceptable site name
      * @return the converted site name
      */
-    public static String bridgifySiteName(String siteName) {
+    public static String bridgifyAndTranslateSiteName(String siteName) {
         if (siteName == null) {
             return null;
         }
-        return siteName.replace("'", "")
+        String adjustedSiteName = siteName;
+        for (String siteNameKey : SITE_LOCATION_TRANSLATION.keySet()) {
+            if (siteNameKey.equals(siteName)) {
+                adjustedSiteName = SITE_LOCATION_TRANSLATION.get(siteNameKey);
+            }
+        }
+        return adjustedSiteName.replace("'", "")
                 .replace(".", "")
                 .replace(" ", "");
     }

--- a/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/MigrationTests.java
+++ b/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/MigrationTests.java
@@ -33,7 +33,6 @@
 package org.sagebionetworks.dian.datamigration;
 
 import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -405,9 +404,16 @@ public class MigrationTests {
     @Test
     public void test_bridgifySiteName() {
         String siteName = null;
-        assertNull(bridgifySiteName(siteName));
+        assertNull(bridgifyAndTranslateSiteName(siteName));
         siteName = "St.Louis' Site";
-        assertEquals("StLouisSite", MigrationUtil.bridgifySiteName(siteName));
+        assertEquals("StLouisSite", MigrationUtil.bridgifyAndTranslateSiteName(siteName));
+    }
+
+    @Test
+    public void test_translateSiteName() {
+        assertEquals("legacy", MigrationUtil.bridgifyAndTranslateSiteName("legacy"));
+        // Must be case-sensitive exact match to move users from "Legacy" to "EXR"
+        assertEquals("EXR", MigrationUtil.bridgifyAndTranslateSiteName("Legacy"));
     }
 
     @Test


### PR DESCRIPTION
The migration code pointed at production bridge/synapse failed to run because of an unknown site location named "Legacy".  

After syncing with the Happy Medium and WashU teams, this should be put in the "EXR" site location.

To fix, I added functionality to the site name that translates "Legacy" site name to "EXR".  