### PR TITLE
MultipleDeviceIdBug

### DIFF
--- a/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/HmDataModel.java
+++ b/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/HmDataModel.java
@@ -39,6 +39,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.sagebionetworks.dian.datamigration.MigrationUtil.ERROR_STUDY_ID;
@@ -275,12 +276,22 @@ public class HmDataModel {
         public static ParticipantDeviceId findParticipantDeviceId(
                 String participantTableId, ParticipantDeviceId[] deviceIdList) {
 
+            List<ParticipantDeviceId> matchingDeviceIds = new ArrayList<>();
             for (ParticipantDeviceId deviceId: deviceIdList) {
                 if (deviceId != null && deviceId.participant.equals(participantTableId)) {
-                    return deviceId;
+                    matchingDeviceIds.add(deviceId);
                 }
             }
-            return null;
+            if (matchingDeviceIds.isEmpty()) {
+                return null;
+            }
+
+            // Sort by oldest first
+            matchingDeviceIds.sort((d1, d2) ->
+                    d1.created_at.compareTo(d2.created_at));
+
+            // Return the last one, which is the most recent
+            return matchingDeviceIds.get(matchingDeviceIds.size() - 1);
         }
 
         @JsonIgnoreProperties(ignoreUnknown = true)

--- a/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/HmDataModelTests.java
+++ b/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/HmDataModelTests.java
@@ -231,11 +231,13 @@ public class HmDataModelTests {
                 HmDataModel.TableRow.findParticipantDeviceId("1", userDeviceIdList);
         assertNotNull(deviceId);
         assertEquals("d1a5cbaf-288c-48dd-9d4a-98c90213ac01", deviceId.device_id);
+        assertEquals("1576165222", deviceId.created_at);
 
         deviceId = HmDataModel.TableRow.findParticipantDeviceId("2", userDeviceIdList);
         assertNotNull(deviceId);
         // There are two matches for that participant, but this is the most recent
         assertEquals("def5cbaf-288c-48dd-9d4a-98c90213ac01", deviceId.device_id);
+        assertEquals("1586165222", deviceId.created_at);
 
         deviceId = HmDataModel.TableRow.findParticipantDeviceId("3", userDeviceIdList);
         assertNull(deviceId);

--- a/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/HmDataModelTests.java
+++ b/DataMigration/src/test/java/org/sagebionetworks/dian/datamigration/HmDataModelTests.java
@@ -221,7 +221,10 @@ public class HmDataModelTests {
                                 "d1a5cbaf-288c-48dd-9d4a-98c90213ac01", "1576165222"),
                         new HmDataModel.TableRow.ParticipantDeviceId(
                                 "2", "2",
-                                "abc5cbaf-288c-48dd-9d4a-98c90213ac01", "1576165222")
+                                "abc5cbaf-288c-48dd-9d4a-98c90213ac01", "1576165222"),
+                        new HmDataModel.TableRow.ParticipantDeviceId(
+                                "3", "2",
+                                "def5cbaf-288c-48dd-9d4a-98c90213ac01", "1586165222")
                 };
 
         HmDataModel.TableRow.ParticipantDeviceId deviceId =
@@ -231,7 +234,8 @@ public class HmDataModelTests {
 
         deviceId = HmDataModel.TableRow.findParticipantDeviceId("2", userDeviceIdList);
         assertNotNull(deviceId);
-        assertEquals("abc5cbaf-288c-48dd-9d4a-98c90213ac01", deviceId.device_id);
+        // There are two matches for that participant, but this is the most recent
+        assertEquals("def5cbaf-288c-48dd-9d4a-98c90213ac01", deviceId.device_id);
 
         deviceId = HmDataModel.TableRow.findParticipantDeviceId("3", userDeviceIdList);
         assertNull(deviceId);


### PR DESCRIPTION
Bug documented in the Jira issue https://sagebionetworks.jira.com/browse/DIAN-183

There are users in production that are reporting an error during migration, because the Device ID on their phone, is not the correct one we parsed in the migration code.  This is because a misunderstanding of the requirement on where duplicate Device IDs would be stored.  

I have verified that this fix corrects the problem by finding all matching Device Ids, sorting it, and then returning the most recent.

After this is merged, a new release should be created and run immediately.