### PR TITLE
Study participant bug fix

### DIFF
--- a/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/BridgeJavaSdkUtil.java
+++ b/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/BridgeJavaSdkUtil.java
@@ -276,10 +276,9 @@ public class BridgeJavaSdkUtil {
     }
 
     public static void updateParticipantClientData(
-            String userId, JsonElement clientDataJson) throws IOException {
-        StudyParticipant participant = new StudyParticipant()
-                .clientData(clientDataJson);
-        participantsApi.updateParticipant(userId, participant).execute();
+            StudyParticipant existing, JsonElement clientDataJson) throws IOException {
+        existing.clientData(clientDataJson);
+        participantsApi.updateParticipant(existing.getId(), existing).execute();
     }
 
     @VisibleForTesting

--- a/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/tools/adherence/SageScheduleController.kt
+++ b/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/tools/adherence/SageScheduleController.kt
@@ -203,10 +203,11 @@ open class SageScheduleController {
         // Sage schedules start with day 1, not 0, so offset to match CompletedTest days,
         // Unless it is the baseline week, where HM had 1-based index
         val dayOfWeekIdx = if(studyBurstWeekNum == 0) {
-            session.startDay
+            session.startDay + 1
         } else {
-            session.startDay - 1
+            session.startDay
         }
+
         val sessionIndex = sessionOfDayIdx(session, dailySessions)
         // Find the matching CompletedTest based of week/day/session_idx
         val matchingTest = earningsController.completedTests.firstOrNull {

--- a/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/tools/schedulev2/ScheduleV2Migration.java
+++ b/DataMigration/src/main/java/org/sagebionetworks/dian/datamigration/tools/schedulev2/ScheduleV2Migration.java
@@ -319,7 +319,7 @@ public class ScheduleV2Migration {
                 // the odd first study burst day offset, let's move all week 0 session a day backwards
                 // so that they match the rest of the study bursts, and have day as 0 for the first day.
                 if ((completed.getWeek() == 0 || completed.getWeek() == 1) && completed.getDay() > 0) {
-                    completed = new CompletedTestV2(completed.getEventId(), completed.getWeek(),
+                    completed = new CompletedTestV2(completed.getEventId(), 0,
                             completed.getDay() - 1, completed.getSession(), completed.getCompletedOn());
                 }
                 adherenceRecordList.add(controller.createAdherenceRecord(session,


### PR DESCRIPTION
We ran the migration code on the ARC Bridge Project study "SageTestAccounts" to go through the full E2E migration process both with this code and in the mobile apps.  One critical bug appeared, it was when I was updating the participant's client data, it was clearing out all the other user information, including the VERIFICATION_CODE attribute, which is how the user signs in. 

This has been fixed by editing the user's existing StudyParticipant object instead of creating a blank one.

In this PR is also a bug fix for adherence records/completed tests, where the original schedule when I wrote this code had startDay in the Bridge V2 schedule as 1, but now with the production V2 schedule we are going to use, startDay is 0. 